### PR TITLE
Update DOTNET_VERSION to 10.x

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -5,7 +5,7 @@ on:
     branches: [ master ]
 
 env:
-  DOTNET_VERSION: 9.x
+  DOTNET_VERSION: 10.x
   SCANNER_VERSION: 10.3.0.120579
   BUILD_CONFIG: Release
 


### PR DESCRIPTION
This pull request updates the .NET version used in the GitHub Actions workflow to ensure compatibility with the latest runtime.

Dependency version update:

* Updated the `DOTNET_VERSION` environment variable from `9.x` to `10.x` in `.github/workflows/dotnetcore.yml` to use .NET 10 for builds and CI.